### PR TITLE
Fix pet expiration config key

### DIFF
--- a/src/main/java/com/github/gpaddons/gpclaimexpiration/config/Configuration.java
+++ b/src/main/java/com/github/gpaddons/gpclaimexpiration/config/Configuration.java
@@ -91,7 +91,7 @@ public class Configuration
         };
         claimExpirationCommands = new StringListSetting(plugin.getConfig(), "expiration.claim.commands", List.of());
 
-        petProtectionDuration = new IntSetting(plugin.getConfig(), "expiration.pets.days", 60);
+        petProtectionDuration = new IntSetting(plugin.getConfig(), "expiration.pet.days", 60);
         petExpirationCommands = new StringListSetting(plugin.getConfig(), "expiration.pet.commands", List.of());
     }
 


### PR DESCRIPTION
Fixes pet expiration days using the documented `expiration.pet.days` config key instead of an unintended `expiration.pets.days` key, so configured pet expiration durations are actually respected.